### PR TITLE
Fix HUGE to HUGE_VAL instead.

### DIFF
--- a/common/image_f32.c
+++ b/common/image_f32.c
@@ -152,7 +152,7 @@ void image_f32_gaussian_blur(image_f32_t *im, double sigma, int ksz)
 // remap all values to [0, 1]
 void image_f32_normalize(image_f32_t *im)
 {
-    float min = HUGE, max = -HUGE;
+    float min = HUGE_VAL, max = -HUGE_VAL;
 
     for (int y = 0; y < im->height; y++) {
         for (int x = 0; x < im->width; x++) {


### PR DESCRIPTION
Fixes a build breakage from Ubuntu 19.10. The same change appears in a different repo here:

https://github.com/versatran01/apriltag/commit/c7b2c30e4196cfa9bcdd05e5fe01f283e322810e